### PR TITLE
Fix controller, models e services

### DIFF
--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/controller/AlunoController.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/controller/AlunoController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import br.edu.ifrs.minicurso.springsolidapi.dto.AlunoDTO;
 import br.edu.ifrs.minicurso.springsolidapi.model.Aluno;
 import br.edu.ifrs.minicurso.springsolidapi.service.interfaces.AlunoService;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 
 @RestController
 @RequestMapping("/aluno")

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/controller/DisciplinaController.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/controller/DisciplinaController.java
@@ -1,0 +1,62 @@
+package br.edu.ifrs.minicurso.springsolidapi.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.edu.ifrs.minicurso.springsolidapi.dto.DisciplinaDTO;
+import br.edu.ifrs.minicurso.springsolidapi.model.Disciplina;
+import br.edu.ifrs.minicurso.springsolidapi.service.interfaces.DisciplinaService;
+
+@RestController
+@RequestMapping("/disciplina")
+public class DisciplinaController {
+    
+    @Autowired
+    private DisciplinaService disciplinaService;
+    
+    @GetMapping
+    public ResponseEntity<List<Disciplina>> getAll() {
+        List<Disciplina> disciplinas = disciplinaService.getAll();
+        return ResponseEntity.ok().body(disciplinas);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Disciplina> getById(@PathVariable int id) throws Exception {
+        Disciplina disciplina = disciplinaService.getById(id);
+        return ResponseEntity.ok().body(disciplina);
+    }
+
+    @PostMapping
+    public ResponseEntity<Disciplina> save(@RequestBody DisciplinaDTO disciplinaDto) {
+        Disciplina disciplina = disciplinaService.save(disciplinaDto);
+        return ResponseEntity.ok().body(disciplina);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Disciplina> update(@PathVariable int id, @RequestBody DisciplinaDTO disciplinaDto) throws Exception {
+        Disciplina disciplina = disciplinaService.update(id, disciplinaDto);
+        return ResponseEntity.ok().body(disciplina);
+    }
+    
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Boolean> delete(@PathVariable int id) {
+        boolean deletado = disciplinaService.delete(id);        
+        if (deletado) {
+            return new ResponseEntity<Boolean>(deletado, HttpStatus.OK);
+        } else {
+            return new ResponseEntity<Boolean>(deletado, HttpStatus.NOT_FOUND);
+        }
+    }
+    
+}

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/controller/TurmaController.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/controller/TurmaController.java
@@ -1,0 +1,74 @@
+package br.edu.ifrs.minicurso.springsolidapi.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.edu.ifrs.minicurso.springsolidapi.dto.TurmaDTO;
+import br.edu.ifrs.minicurso.springsolidapi.model.Turma;
+import br.edu.ifrs.minicurso.springsolidapi.service.interfaces.TurmaService;
+
+@RestController
+@RequestMapping("/turma")
+public class TurmaController {
+
+    @Autowired
+    private TurmaService turmaService;
+    
+    @GetMapping
+    public ResponseEntity<List<Turma>> getAll() {
+        List<Turma> turmas = turmaService.getAll();
+        return ResponseEntity.ok().body(turmas);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Turma> getById(@PathVariable int id) throws Exception {
+        Turma turma = turmaService.getById(id);
+        return ResponseEntity.ok().body(turma);
+    }
+
+    @PostMapping
+    public ResponseEntity<Turma> save(@RequestBody TurmaDTO turmaDto) throws Exception {
+        Turma turma = turmaService.save(turmaDto);
+        return ResponseEntity.ok().body(turma);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Turma> update(@PathVariable int id, @RequestBody TurmaDTO turmaDto) throws Exception {
+        Turma turma = turmaService.update(id, turmaDto);
+        return ResponseEntity.ok().body(turma);
+    }
+    
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Boolean> delete(@PathVariable int id) {
+        boolean deletado = turmaService.delete(id);        
+        if (deletado) {
+            return new ResponseEntity<Boolean>(deletado, HttpStatus.OK);
+        } else {
+            return new ResponseEntity<Boolean>(deletado, HttpStatus.NOT_FOUND);
+        }
+    }
+    
+    @PostMapping("/{turma_id}/{aluno_id}")
+    public ResponseEntity<Turma> addAluno(@PathVariable int turma_id, @PathVariable int aluno_id) throws Exception {
+        Turma turma = turmaService.addAluno(turma_id, aluno_id);
+        return ResponseEntity.ok().body(turma);
+    }
+
+    @DeleteMapping("/{turma_id}/{aluno_id}")
+    public ResponseEntity<Turma> removeAluno(@PathVariable int turma_id, @PathVariable int aluno_id) throws Exception {
+        Turma turma = turmaService.removeAluno(turma_id, aluno_id);
+        return ResponseEntity.ok().body(turma);
+    }
+    
+}

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/model/Aluno.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/model/Aluno.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -42,7 +41,7 @@ public class Aluno {
     @Column(length = 255, unique = true)
     private String email;
     
-    @ManyToMany(mappedBy = "alunos", cascade = CascadeType.ALL)
+    @ManyToMany(mappedBy = "alunos")
     @JsonIgnoreProperties("alunos")
     private List<Turma> turmas;
     

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/model/Aluno.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/model/Aluno.java
@@ -2,6 +2,8 @@ package br.edu.ifrs.minicurso.springsolidapi.model;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -41,6 +43,7 @@ public class Aluno {
     private String email;
     
     @ManyToMany(mappedBy = "alunos", cascade = CascadeType.ALL)
+    @JsonIgnoreProperties("alunos")
     private List<Turma> turmas;
     
 }

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/model/Disciplina.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/model/Disciplina.java
@@ -2,6 +2,8 @@ package br.edu.ifrs.minicurso.springsolidapi.model;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -34,6 +36,7 @@ public class Disciplina {
     private Integer semestre;
 
     @OneToMany(mappedBy = "disciplina")
+    @JsonIgnoreProperties("alunos")
     private List<Turma> turmas;
 
 }

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/model/Turma.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/model/Turma.java
@@ -2,6 +2,8 @@ package br.edu.ifrs.minicurso.springsolidapi.model;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -36,10 +38,12 @@ public class Turma {
 
     @ManyToOne
     @JoinColumn(name = "disciplina_id")
+    @JsonIgnoreProperties("turmas")
     private Disciplina disciplina;
 
     @ManyToMany(cascade = CascadeType.ALL)
     @JoinTable(name = "aluno_turma", joinColumns = @JoinColumn(name = "turma_id"), inverseJoinColumns = @JoinColumn(name = "aluno_id"))
+    @JsonIgnoreProperties("turmas")
     private List<Aluno> alunos;
 
 }

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/model/Turma.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/model/Turma.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -41,7 +40,7 @@ public class Turma {
     @JsonIgnoreProperties("turmas")
     private Disciplina disciplina;
 
-    @ManyToMany(cascade = CascadeType.ALL)
+    @ManyToMany
     @JoinTable(name = "aluno_turma", joinColumns = @JoinColumn(name = "turma_id"), inverseJoinColumns = @JoinColumn(name = "aluno_id"))
     @JsonIgnoreProperties("turmas")
     private List<Aluno> alunos;

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/repository/AlunoRepository.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/repository/AlunoRepository.java
@@ -2,8 +2,14 @@ package br.edu.ifrs.minicurso.springsolidapi.repository;
 
 import br.edu.ifrs.minicurso.springsolidapi.model.Aluno;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AlunoRepository extends JpaRepository<Aluno, Integer> {
+
+    @Query("SELECT CASE WHEN COUNT(a) > 0 THEN true ELSE false END FROM Aluno a WHERE a.matricula = :matricula")
+    boolean existsByMatricula(@Param("matricula") String matricula);
+    
 }

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/AlunoServiceImpl.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/AlunoServiceImpl.java
@@ -1,6 +1,8 @@
 package br.edu.ifrs.minicurso.springsolidapi.service;
 
+import java.time.Year;
 import java.util.List;
+import java.util.Random;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -11,7 +13,7 @@ import br.edu.ifrs.minicurso.springsolidapi.repository.AlunoRepository;
 import br.edu.ifrs.minicurso.springsolidapi.service.interfaces.AlunoService;
 
 @Service
-public class AlunoServiceImpl implements AlunoService{
+public class AlunoServiceImpl implements AlunoService {
 
     @Autowired
     private AlunoRepository alunoRepository;
@@ -23,7 +25,7 @@ public class AlunoServiceImpl implements AlunoService{
 
     @Override
     public Aluno getById(int id) throws Exception {
-       return alunoRepository.findById(id).orElseThrow(() -> new Exception("Aluno não encontrado."));
+        return alunoRepository.findById(id).orElseThrow(() -> new Exception("Aluno não encontrado."));
     }
 
     @Override
@@ -31,6 +33,19 @@ public class AlunoServiceImpl implements AlunoService{
         Aluno aluno = new Aluno();
         aluno.setNome(alunoDto.nome());
         aluno.setSobrenome(alunoDto.sobrenome());
+
+        String matricula = generateMatricula();
+        while (alunoRepository.existsByMatricula(matricula)) {
+            matricula = generateMatricula();
+        }
+
+        aluno.setMatricula(matricula);
+        aluno.setEmail(generateEmail(alunoDto.nome(), alunoDto.sobrenome()));
+        return alunoRepository.save(aluno);
+    }
+
+    // Sobrecarga do método de salvar aluno.
+    public Aluno save(Aluno aluno) {
         return alunoRepository.save(aluno);
     }
 
@@ -39,6 +54,7 @@ public class AlunoServiceImpl implements AlunoService{
         Aluno aluno = getById(id);
         aluno.setNome(alunoDto.nome());
         aluno.setSobrenome(alunoDto.sobrenome());
+        aluno.setEmail(generateEmail(alunoDto.nome(), alunoDto.sobrenome()));
         return alunoRepository.save(aluno);
     }
 
@@ -52,4 +68,12 @@ public class AlunoServiceImpl implements AlunoService{
         }
     }
 
+    private String generateMatricula() {
+        Random random = new Random();
+        return String.format("%d%06d", Year.now().getValue(), random.nextInt(1000000));
+    }
+
+    private String generateEmail(String nome, String sobrenome) {
+        return String.format("%s.%s@aluno.riogrande.ifrs.edu.br", nome.toLowerCase(), sobrenome.toLowerCase());
+    }
 }

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/AlunoServiceImpl.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/AlunoServiceImpl.java
@@ -45,6 +45,7 @@ public class AlunoServiceImpl implements AlunoService {
     }
 
     // Sobrecarga do método de salvar aluno.
+    @Override
     public Aluno save(Aluno aluno) {
         return alunoRepository.save(aluno);
     }

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/DisciplinaServiceImpl.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/DisciplinaServiceImpl.java
@@ -3,12 +3,14 @@ package br.edu.ifrs.minicurso.springsolidapi.service;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import br.edu.ifrs.minicurso.springsolidapi.dto.DisciplinaDTO;
 import br.edu.ifrs.minicurso.springsolidapi.model.Disciplina;
 import br.edu.ifrs.minicurso.springsolidapi.repository.DisciplinaRepository;
 import br.edu.ifrs.minicurso.springsolidapi.service.interfaces.DisciplinaService;
 
+@Service
 public class DisciplinaServiceImpl implements DisciplinaService {
 
     @Autowired

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/TurmaServiceImpl.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/TurmaServiceImpl.java
@@ -3,19 +3,26 @@ package br.edu.ifrs.minicurso.springsolidapi.service;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import br.edu.ifrs.minicurso.springsolidapi.dto.TurmaDTO;
+import br.edu.ifrs.minicurso.springsolidapi.model.Aluno;
 import br.edu.ifrs.minicurso.springsolidapi.model.Disciplina;
 import br.edu.ifrs.minicurso.springsolidapi.model.Turma;
 import br.edu.ifrs.minicurso.springsolidapi.repository.TurmaRepository;
 import br.edu.ifrs.minicurso.springsolidapi.service.interfaces.TurmaService;
 
-public class TurmaServiceImpl implements TurmaService{
+@Service
+public class TurmaServiceImpl implements TurmaService {
 
     @Autowired
     private TurmaRepository turmaRepository;
+
     @Autowired
     private DisciplinaServiceImpl disciplinaServiceImpl;
+
+    @Autowired
+    private AlunoServiceImpl alunoServiceImpl;
 
     @Override
     public List<Turma> getAll() {
@@ -34,7 +41,7 @@ public class TurmaServiceImpl implements TurmaService{
 
         turma.setNome(turmaDto.nome());
         turma.setDisciplina(disciplina);
-        
+
         return turmaRepository.save(turma);
     }
 
@@ -45,7 +52,7 @@ public class TurmaServiceImpl implements TurmaService{
 
         turma.setNome(turmaDto.nome());
         turma.setDisciplina(disciplina);
-        
+
         return turmaRepository.save(turma);
     }
 
@@ -58,5 +65,35 @@ public class TurmaServiceImpl implements TurmaService{
             return false;
         }
     }
-    
+
+    public Turma addAluno(int turma_id, int aluno_id) throws Exception {
+        Aluno aluno = alunoServiceImpl.getById(aluno_id);
+        Turma turma = getById(turma_id);
+
+        if (turma.getAlunos().contains(aluno)) {
+            throw new IllegalArgumentException("Aluno já está inserido na turma.");
+        }
+
+        turma.getAlunos().add(aluno);
+        aluno.getTurmas().add(turma);
+        turmaRepository.save(turma);
+        alunoServiceImpl.save(aluno);
+        return turma;
+    }
+
+    public Turma removeAluno(int turma_id, int aluno_id) throws Exception {
+        Aluno aluno = alunoServiceImpl.getById(aluno_id);
+        Turma turma = getById(turma_id);
+
+        if (!turma.getAlunos().contains(aluno)) {
+            throw new IllegalArgumentException("Aluno não pertenca a turma.");
+        }
+
+        turma.getAlunos().remove(aluno);
+        aluno.getTurmas().remove(turma);
+        turmaRepository.save(turma);
+        alunoServiceImpl.save(aluno);
+        return turma;
+    }
+
 }

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/TurmaServiceImpl.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/TurmaServiceImpl.java
@@ -10,6 +10,8 @@ import br.edu.ifrs.minicurso.springsolidapi.model.Aluno;
 import br.edu.ifrs.minicurso.springsolidapi.model.Disciplina;
 import br.edu.ifrs.minicurso.springsolidapi.model.Turma;
 import br.edu.ifrs.minicurso.springsolidapi.repository.TurmaRepository;
+import br.edu.ifrs.minicurso.springsolidapi.service.interfaces.AlunoService;
+import br.edu.ifrs.minicurso.springsolidapi.service.interfaces.DisciplinaService;
 import br.edu.ifrs.minicurso.springsolidapi.service.interfaces.TurmaService;
 
 @Service
@@ -19,10 +21,10 @@ public class TurmaServiceImpl implements TurmaService {
     private TurmaRepository turmaRepository;
 
     @Autowired
-    private DisciplinaServiceImpl disciplinaServiceImpl;
+    private DisciplinaService disciplinaService;
 
     @Autowired
-    private AlunoServiceImpl alunoServiceImpl;
+    private AlunoService alunoService;
 
     @Override
     public List<Turma> getAll() {
@@ -37,7 +39,7 @@ public class TurmaServiceImpl implements TurmaService {
     @Override
     public Turma save(TurmaDTO turmaDto) throws Exception {
         Turma turma = new Turma();
-        Disciplina disciplina = disciplinaServiceImpl.getById(turmaDto.disciplina_id());
+        Disciplina disciplina = disciplinaService.getById(turmaDto.disciplina_id());
 
         turma.setNome(turmaDto.nome());
         turma.setDisciplina(disciplina);
@@ -48,7 +50,7 @@ public class TurmaServiceImpl implements TurmaService {
     @Override
     public Turma update(int id, TurmaDTO turmaDto) throws Exception {
         Turma turma = getById(id);
-        Disciplina disciplina = disciplinaServiceImpl.getById(turmaDto.disciplina_id());
+        Disciplina disciplina = disciplinaService.getById(turmaDto.disciplina_id());
 
         turma.setNome(turmaDto.nome());
         turma.setDisciplina(disciplina);
@@ -67,7 +69,7 @@ public class TurmaServiceImpl implements TurmaService {
     }
 
     public Turma addAluno(int turma_id, int aluno_id) throws Exception {
-        Aluno aluno = alunoServiceImpl.getById(aluno_id);
+        Aluno aluno = alunoService.getById(aluno_id);
         Turma turma = getById(turma_id);
 
         if (turma.getAlunos().contains(aluno)) {
@@ -77,12 +79,12 @@ public class TurmaServiceImpl implements TurmaService {
         turma.getAlunos().add(aluno);
         aluno.getTurmas().add(turma);
         turmaRepository.save(turma);
-        alunoServiceImpl.save(aluno);
+        alunoService.save(aluno);
         return turma;
     }
 
     public Turma removeAluno(int turma_id, int aluno_id) throws Exception {
-        Aluno aluno = alunoServiceImpl.getById(aluno_id);
+        Aluno aluno = alunoService.getById(aluno_id);
         Turma turma = getById(turma_id);
 
         if (!turma.getAlunos().contains(aluno)) {
@@ -92,7 +94,7 @@ public class TurmaServiceImpl implements TurmaService {
         turma.getAlunos().remove(aluno);
         aluno.getTurmas().remove(turma);
         turmaRepository.save(turma);
-        alunoServiceImpl.save(aluno);
+        alunoService.save(aluno);
         return turma;
     }
 

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/interfaces/AlunoService.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/interfaces/AlunoService.java
@@ -16,6 +16,8 @@ public interface AlunoService {
 
     Aluno save(AlunoDTO alunoDto);
 
+    Aluno save(Aluno aluno);
+
     Aluno update(int id, AlunoDTO alunoDto) throws Exception;
 
     boolean delete(int id);

--- a/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/interfaces/TurmaService.java
+++ b/src/main/java/br/edu/ifrs/minicurso/springsolidapi/service/interfaces/TurmaService.java
@@ -2,9 +2,12 @@ package br.edu.ifrs.minicurso.springsolidapi.service.interfaces;
 
 import java.util.List;
 
+import org.springframework.stereotype.Service;
+
 import br.edu.ifrs.minicurso.springsolidapi.dto.TurmaDTO;
 import br.edu.ifrs.minicurso.springsolidapi.model.Turma;
 
+@Service
 public interface TurmaService {
     List<Turma> getAll();
 
@@ -12,7 +15,12 @@ public interface TurmaService {
 
     Turma save(TurmaDTO turmaDto) throws Exception;
 
+    Turma addAluno(int turma_id, int aluno_id) throws Exception;
+
+    Turma removeAluno(int turma_id, int aluno_id) throws Exception;
+
     Turma update(int id, TurmaDTO turmaDto) throws Exception;
 
     boolean delete(int id);
+
 }


### PR DESCRIPTION
Adicionei a lógica para gerar o e-mail institucional e o número de matrícula do aluno automaticamente.
Adicionei a lógica para inserir e remover um aluno de uma turma.
Adicionei a notation "JsonIgnoreProperties" nos models, para evitar ciclo infinito nas APIs.
Sobrecarreguei o método de salvar um aluno, para receber como parâmetro um objeto de Aluno ao invés da DTO, e poder usar a interface de AlunoService em TurmaServiceImpl, ao invés de acessar diretamente a camada do Repository.
Corrigi os imports do ResponseBody nos controllers, estava causando erro nas APIs pois o que havia sido importado era do Swagger e não do Spring.
Alterei em TurmaServiceImpl a injeção dos services de DisciplinaServiceImpl e AlunoServiceImpl para, DisciplinaService e AlunoService. Para usarmos a interface ao invés da classe de implementação.